### PR TITLE
Reduce the minimum deployment target to iOS 8.0

### DIFF
--- a/VIMVideoPlayer.xcodeproj/project.pbxproj
+++ b/VIMVideoPlayer.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = VIMVideoKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vimeo.VIMVideoKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -447,7 +447,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = VIMVideoKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vimeo.VIMVideoKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This PR reduces the minimum deployment target to iOS 8.0. Tested and confirmed to be working against Xcode 7.2 and Swift 2.1.1.