### PR TITLE
VIM-3520: Airplay Mirror Bug

### DIFF
--- a/VIMVideoPlayer-Source/VIMVideoPlayer.m
+++ b/VIMVideoPlayer-Source/VIMVideoPlayer.m
@@ -99,6 +99,8 @@ static void *VideoPlayer_PlayerItemLoadedTimeRangesContext = &VideoPlayer_Player
     self.muted = NO;
     self.looping = NO;
     
+    self.player.usesExternalPlaybackWhileExternalScreenIsActive = YES;
+    
     [self setVolume:1.0f];
     [self enableTimeUpdates];
     [self enableAirplay];


### PR DESCRIPTION
#### Ticket

https://vimean.atlassian.net/browse/VIM-3520

#### Ticket Summary

The "Connected to AirPlay" overlay is displayed when in AirPlay mirroring mode, not just when AirPlay streaming mode.

#### Implementation Summary

Added `self.player.usesExternalPlaybackWhileExternalScreenIsActive = YES;`, which causes the player to switch to AirPlay streaming when the device is AirPlay mirroring when playing a video.

#### How to Test

See ticket.