### PR TITLE
VIM-4503: Session time

### DIFF
--- a/VIMVideoPlayer-Source/VIMVideoPlayer.h
+++ b/VIMVideoPlayer-Source/VIMVideoPlayer.h
@@ -29,6 +29,8 @@
 
 @class VIMVideoPlayer;
 
+static const float TimeUpdateInterval = 0.1f;
+
 @protocol VIMVideoPlayerDelegate <NSObject>
 
 @optional

--- a/VIMVideoPlayer-Source/VIMVideoPlayer.m
+++ b/VIMVideoPlayer-Source/VIMVideoPlayer.m
@@ -28,7 +28,6 @@
 
 static const float DefaultPlayableBufferLength = 2.0f;
 static const float DefaultVolumeFadeDuration = 1.0f;
-static const float TimeObserverInterval = 0.01f;
 
 NSString * const kVideoPlayerErrorDomain = @"kVideoPlayerErrorDomain";
 
@@ -644,7 +643,7 @@ static void *VideoPlayer_PlayerItemLoadedTimeRangesContext = &VideoPlayer_Player
     }
     
     __weak typeof (self) weakSelf = self;
-    self.timeObserverToken = [self.player addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(TimeObserverInterval, NSEC_PER_SEC) queue:dispatch_get_main_queue() usingBlock:^(CMTime time) {
+    self.timeObserverToken = [self.player addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(TimeUpdateInterval, NSEC_PER_SEC) queue:dispatch_get_main_queue() usingBlock:^(CMTime time) {
         
         __strong typeof (self) strongSelf = weakSelf;
         if (!strongSelf)


### PR DESCRIPTION
#### Ticket

https://vimean.atlassian.net/browse/VIM-4503

#### Ticket Summary

The current play logging events require `session_time` to be sent with the `exit` and `play` events. `session_time` is the total time the user has spent watching the video with the video actually playing. This ticket is for adding that parameter to those requests. Play logging spec here:

https://docs.google.com/document/d/1B4FPhSK_TECdygjgRhGLFx9vZUeg-9zePOqV5zD5RF0/edit#

This is a temporary implementation since we'll be overhauling our play logging with the new, unfinished spec that will be built by the API in the next few sprints.

#### Implementation Summary

Moving the `TimeUpdateInterval` constant to the header. This makes sense since as a user of this class, you can enable and disable time updates. It makes sense that you should be able to see at what interval these updates fire.

Also changed the name of this constant from `TimeObserverInterval` to `TimeUpdateInterval` to match the `enableTimeUpdates` and `disableTimeUpdates` function names.

Associated PR: https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/951

#### How to Test

N/A