### PR TITLE
VIM-4419: DRM player error UI

### DIFF
--- a/VIMVideoPlayer-Source/VIMVideoPlayer.m
+++ b/VIMVideoPlayer-Source/VIMVideoPlayer.m
@@ -720,12 +720,29 @@ static void *VideoPlayer_PlayerItemLoadedTimeRangesContext = &VideoPlayer_Player
                     NSLog(@"Video player Status Failed: player item error = %@", self.player.currentItem.error);
                     NSLog(@"Video player Status Failed: player error = %@", self.player.error);
                     
+                    // First, try to use the player error if it exists
+
                     NSError *error = self.player.error;
+                    
+                    // Otherwise try to use the current item's error
+                    
                     if (!error)
                     {
                         error = self.player.currentItem.error;
                     }
-                    else
+                    
+                    // If there's a more specific underlyng error, use that
+                    
+                    NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
+                    
+                    if (underlyingError)
+                    {
+                        error = underlyingError;
+                    }
+
+                    // Finally, construct our own as a last resort
+                    
+                    if (!error)
                     {
                         error = [NSError errorWithDomain:kVideoPlayerErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"unknown player error, status == AVPlayerItemStatusFailed"}];
                     }


### PR DESCRIPTION
#### Ticket

https://vimean.atlassian.net/browse/VIM-4419

#### Ticket Summary

This implements UI states for DRM-specific errors in the player.

#### Implementation Summary

Since NSErrors from a failed AVAssetResourceLoadingRequest are propagated back to our video player as an underlying error, I added steps to select the appropriate error object in our status observer KVO. 

It's kind of a bummer that an NSObject can come from three different places (Who is to say which one we want to forward on?) but this seems like a reasonable selection process.

Associated PR: https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/960

#### How to Test

See associated PR.