### PR TITLE
make setupAudioSession public and do not call it by default

### DIFF
--- a/VIMVideoPlayer-Source/VIMVideoPlayer.h
+++ b/VIMVideoPlayer-Source/VIMVideoPlayer.h
@@ -58,6 +58,10 @@ static const float TimeUpdateInterval = 0.1f;
 - (void)setPlayerItem:(AVPlayerItem *)playerItem;
 - (void)setAsset:(AVAsset *)asset;
 
+// AVAudioSession
+
+- (void)setupAudioSession;
+
 // Playback
 
 - (void)play;

--- a/VIMVideoPlayer-Source/VIMVideoPlayer.m
+++ b/VIMVideoPlayer-Source/VIMVideoPlayer.m
@@ -82,8 +82,6 @@ static void *VideoPlayer_PlayerItemLoadedTimeRangesContext = &VideoPlayer_Player
         [self setupPlayer];
         
         [self addPlayerObservers];
-
-        [self setupAudioSession];
     }
     
     return self;


### PR DESCRIPTION
#### Ticket Summary

Do not setup the AVAudioSession by default.
#### Implementation Summary

We need another AVAudioSession when you setting up by default.
I just made the setupAudiSession public and don't call it by default.
So everybody can decide himself to setup the session as he likes it.
#### How to Test
